### PR TITLE
Make the change seq no. available as $seq for change params

### DIFF
--- a/src/change-processor.js
+++ b/src/change-processor.js
@@ -56,6 +56,10 @@ class ChangeProcessor {
             params[name] = change.doc
             break
 
+          case '$seq':
+            params[name] = change.seq
+            break
+
           default:
             params[name] = value
         }

--- a/test/spec/change-processor.js
+++ b/test/spec/change-processor.js
@@ -15,7 +15,9 @@ describe('change-processor', () => {
     _rev: '1',
     thing: 'jam'
   }
+  let seq = '123-xyz'
   let change = {
+    seq,
     doc
   }
   let origReq = null
@@ -81,7 +83,8 @@ describe('change-processor', () => {
       params: {
         foo: 'bar',
         change: '$change',
-        db_name: '$db_name'
+        db_name: '$db_name',
+        seq: '$seq'
       }
     }
 
@@ -90,7 +93,8 @@ describe('change-processor', () => {
     params.should.eql({
       foo: 'bar',
       change: change.doc,
-      db_name: 'test_db1'
+      db_name: 'test_db1',
+      seq: change.seq
     })
   })
 


### PR DESCRIPTION
Add '$seq' to '$change' and '$db_name' as special values for inclusion
in the 'params' option for on_change documents to get access to the 'seq'
value from the change event in the API call.