### PR TITLE
Delete change_listener docs after delay if database not found

### DIFF
--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -80,6 +80,13 @@ Options:
                             Applies to: change-listener, replicator
                             Default: 10800
 
+  --assume-deleted-after=secs
+                            Database not found errors that persist for this many seconds
+                            will result in the item document being deleted.
+
+                            Applies to: change-listener, replicator
+                            Default: 300
+
   --concurrency=num         The maximum number of items that will be processed concurrently.
                             Warning: setting this value too high can result in the process using a
                             lot of memory as it queues tasks.

--- a/src/change-listeners.js
+++ b/src/change-listeners.js
@@ -225,7 +225,7 @@ class ChangeListeners extends Process {
       limit: this._batchSize
     }).catch(err => {
       if (err.error === 'not_found') {
-        throw new DatabaseNotFoundError(listener.db_name)
+        err = new DatabaseNotFoundError(listener.db_name)
       }
       throw err
     })

--- a/src/change-listeners.js
+++ b/src/change-listeners.js
@@ -200,13 +200,6 @@ class ChangeListeners extends Process {
     }
   }
 
-  async destroy(dbNames) {
-    let listeners = await this._getByDBNames(dbNames)
-    listeners.map(async (listener) => {
-      await this._getAndDestroy(listener._id)
-    })
-  }
-
   _processChange(change, dbName, requests) {
     return this._changeProcessor.process(change, dbName, requests)
   }
@@ -231,7 +224,7 @@ class ChangeListeners extends Process {
       include_docs: true,
       limit: this._batchSize
     }).catch(err => {
-      if(err.error == 'not_found') {
+      if (err.error === 'not_found') {
         throw new DatabaseNotFoundError(listener.db_name)
       }
       throw err
@@ -283,7 +276,7 @@ class ChangeListeners extends Process {
     try {
       await this._processBatchOfChanges(listener)
     } catch (err) {
-      if(err instanceof DatabaseNotFoundError) {
+      if (err instanceof DatabaseNotFoundError) {
         throw err
       }
       // Log and emit error

--- a/src/cl-params.js
+++ b/src/cl-params.js
@@ -23,12 +23,14 @@ class CLParams {
         concurrency: 'concurrency',
         'retry-after': 'retryAfterSeconds',
         'check-stalled': 'checkStalledSeconds',
+        'assume-deleted-after': 'assumeDeletedAfterSeconds',
         'passwords-file': 'passwords'
       },
       replicator: {
         concurrency: 'concurrency',
         'retry-after': 'retryAfterSeconds',
         'check-stalled': 'checkStalledSeconds',
+        'assume-deleted-after': 'assumeDeletedAfterSeconds',
         'passwords-file': 'passwords'
       }
     }

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,9 @@
+class DatabaseNotFoundError extends Error {
+  constructor(message, ...args) {
+    super('Database not found: ' + message, ...args)
+  }
+}
+
+module.exports = {
+  DatabaseNotFoundError
+}

--- a/src/process.js
+++ b/src/process.js
@@ -274,7 +274,8 @@ class Process extends events.EventEmitter {
     //  replicated to our node yet.  Compromise by deleting the item
     //  if updated_at is long ago enough
     return (
-      new Date().getTime() - new Date(item.updated_at).getTime() > this._assumeDeletedAfterSeconds * 1000
+      new Date().getTime() - new Date(item.updated_at).getTime() >
+        this._assumeDeletedAfterSeconds * 1000
     )
   }
 
@@ -285,8 +286,7 @@ class Process extends events.EventEmitter {
     } catch (err) {
       // If an error is encountered when processing then leave the item dirty, but unlock it so that
       // the processing can be tried again
-      if(err instanceof DatabaseNotFoundError && this._isProbablyDeleted(item)) {
-        log.info('Destroying',item._id)
+      if (err instanceof DatabaseNotFoundError && this._isProbablyDeleted(item)) {
         await this._getAndDestroy(item._id)
       } else {
         await this._upsertUnlock(item)

--- a/src/process.js
+++ b/src/process.js
@@ -5,6 +5,7 @@ const log = require('./log')
 const sporks = require('sporks')
 const events = require('events')
 const utils = require('./utils')
+const { DatabaseNotFoundError } = require('./errors')
 
 class Process extends events.EventEmitter {
   constructor(spiegel, opts, type) {
@@ -28,6 +29,10 @@ class Process extends events.EventEmitter {
     // retried. Be careful not make checkStalledSeconds too low though or else you'll waste a lot of
     // CPU cycles just checking for stalled processes.
     this._checkStalledSeconds = utils.getOpt(opts, 'checkStalledSeconds', 600)
+
+    // The longest we will ignore not_found errors for change listeners
+    //  before assuming it was deleted
+    this._assumeDeletedAfterSeconds = utils.getOpt(opts, 'assumeDeletedAfterSeconds', 300)
   }
 
   _createDirtyAndUnLockedView() {
@@ -264,6 +269,15 @@ class Process extends events.EventEmitter {
     }
   }
 
+  _isProbablyDeleted(item) {
+    // Can't really tell if a database has been deleted or just hasn't been
+    //  replicated to our node yet.  Compromise by deleting the item
+    //  if updated_at is long ago enough
+    return (
+      new Date().getTime() - new Date(item.updated_at).getTime() > this._assumeDeletedAfterSeconds * 1000
+    )
+  }
+
   async _processAndUnlockIfError(item) {
     try {
       let leaveDirty = await this._process(item)
@@ -271,7 +285,12 @@ class Process extends events.EventEmitter {
     } catch (err) {
       // If an error is encountered when processing then leave the item dirty, but unlock it so that
       // the processing can be tried again
-      await this._upsertUnlock(item)
+      if(err instanceof DatabaseNotFoundError && this._isProbablyDeleted(item)) {
+        log.info('Destroying',item._id)
+        await this._getAndDestroy(item._id)
+      } else {
+        await this._upsertUnlock(item)
+      }
       throw err
     }
   }

--- a/test/spec/change-listeners.js
+++ b/test/spec/change-listeners.js
@@ -1,8 +1,10 @@
 'use strict'
 
 const ChangeListeners = require('../../src/change-listeners')
+const { DatabaseNotFoundError } = require('../../src/errors')
 const testUtils = require('../utils')
 const sporks = require('sporks')
+const sandbox = require('sinon').createSandbox()
 
 describe('change-listeners', () => {
   let listeners = null
@@ -49,6 +51,8 @@ describe('change-listeners', () => {
     )
 
     await testUtils.destroyTestDBs()
+
+    sandbox.restore()
   })
 
   it('should get changes when last_seq undefined', () => {
@@ -63,6 +67,18 @@ describe('change-listeners', () => {
     fakeSlouchChangesArray()
     listeners._changesForListener({ db_name: 'test_db1', last_seq: 'last-seq' })
     calls._changesArray[0][1].should.eql({ since: 'last-seq', include_docs: true, limit: 100 })
+  })
+
+  it('should throw DatabaseNotFoundError for missing database', () => {
+    let throwStub = sandbox.stub(listeners, '_changesArray')
+    throwStub.rejects({'error': 'not_found'})
+    return listeners._changesForListener({ db_name: 'test_db1' })
+      .then(() => {
+        throw new Error('should throw error')
+      })
+      .catch(err => {
+        err.should.instanceOf(DatabaseNotFoundError)
+      })
   })
 
   it('should process changes sequentially', async() => {

--- a/test/spec/change-listeners.js
+++ b/test/spec/change-listeners.js
@@ -72,12 +72,24 @@ describe('change-listeners', () => {
   it('should throw DatabaseNotFoundError for missing database', () => {
     let throwStub = sandbox.stub(listeners, '_changesArray')
     throwStub.rejects({'error': 'not_found'})
-    return listeners._changesForListener({ db_name: 'test_db1' })
+    return listeners._processBatchOfChangesLogError({ db_name: 'test_db1' })
       .then(() => {
         throw new Error('should throw error')
       })
       .catch(err => {
         err.should.instanceOf(DatabaseNotFoundError)
+      })
+  })
+
+  it('should not throw DatabaseNotFoundError for other errors', () => {
+    let throwStub = sandbox.stub(listeners, '_changesArray')
+    throwStub.rejects({'error': 'something_else'})
+    return listeners._processBatchOfChangesLogError({ db_name: 'test_db1' })
+      .then(() => {
+        throw new Error('should throw error')
+      })
+      .catch(err => {
+        err.should.not.instanceOf(DatabaseNotFoundError)
       })
   })
 

--- a/test/spec/process.js
+++ b/test/spec/process.js
@@ -60,7 +60,10 @@ describe('process', () => {
   }
 
   before(async() => {
-    globalProc = new Process(testUtils.spiegel, { retryAfterSeconds, checkStalledSeconds, assumeDeletedAfterSeconds }, type)
+    globalProc =
+      new Process(testUtils.spiegel,
+        { retryAfterSeconds, checkStalledSeconds, assumeDeletedAfterSeconds },
+        type)
     await globalProc._createViews()
   })
 
@@ -69,7 +72,10 @@ describe('process', () => {
   })
 
   beforeEach(async() => {
-    proc = new Process(testUtils.spiegel, { retryAfterSeconds, checkStalledSeconds, assumeDeletedAfterSeconds }, type)
+    proc =
+      new Process(testUtils.spiegel,
+        { retryAfterSeconds, checkStalledSeconds, assumeDeletedAfterSeconds },
+        type)
     itemIds = []
     spy()
     listenForErrors()


### PR DESCRIPTION
Fixes #112 

Does not yet have any tests, since I could not easily figure out how to add them.  Any advice would be welcome.

Still has a slight issue, in that it logs 10 or 12 error messages per second (on my machine) for the 5 minutes (configurable) that it is waiting before deciding to delete the change_listener.  Perhaps #53 can be leveraged to avoid that, once someone (maybe me) finishes it?