### PR TITLE
make invalid type option an error

### DIFF
--- a/src/spiegel.js
+++ b/src/spiegel.js
@@ -79,8 +79,7 @@ class Spiegel {
         break
 
       default:
-        log.fatal('unknown type: ' + this._type + ' v' + pkg.version)
-        break
+        throw new Error('unknown type: ' + this._type)
     }
   }
 

--- a/src/spiegel.js
+++ b/src/spiegel.js
@@ -77,6 +77,10 @@ class Spiegel {
       case 'uninstall':
         await this.uninstall()
         break
+
+      default:
+        log.fatal('unknown type: ' + this._type + ' v' + pkg.version)
+        break
     }
   }
 

--- a/test/spec/spiegel.js
+++ b/test/spec/spiegel.js
@@ -127,4 +127,15 @@ describe('spiegel', () => {
   it('should start and stop uninstall', async() => {
     await shouldStartAndStop('uninstall')
   })
+
+  it('should start and stop invalidcommand', async() => {
+    let err = null
+    try {
+      await shouldStartAndStop('invalidcommand')
+    } catch (_err) {
+      err = _err
+    }
+
+    testUtils.shouldNotEqual(err, null)
+  })
 })

--- a/test/spec/spiegel.js
+++ b/test/spec/spiegel.js
@@ -128,7 +128,7 @@ describe('spiegel', () => {
     await shouldStartAndStop('uninstall')
   })
 
-  it('should start and stop invalidcommand', async() => {
+  it('should throw for start invalidcommand', async() => {
     let err = null
     try {
       await shouldStartAndStop('invalidcommand')

--- a/test/spec/spiegel.js
+++ b/test/spec/spiegel.js
@@ -129,13 +129,11 @@ describe('spiegel', () => {
   })
 
   it('should throw for start invalidcommand', async() => {
-    let err = null
-    try {
-      await shouldStartAndStop('invalidcommand')
-    } catch (_err) {
-      err = _err
-    }
-
-    testUtils.shouldNotEqual(err, null)
+    await sporks.shouldThrow(
+      () => {
+        return shouldStartAndStop('invalidcommand')
+      },
+      { name: 'Error' }
+    )
   })
 })


### PR DESCRIPTION
Hi @redgeoff, thank you for integrating the additional variables support! Another thing that has come up a few times while starting to use spiegel was mis-spelling the --type values to the cli and then not realizing why nothing happened. (I.e. when typing `--type=init` or `--type=change_listener` by mistake they look like they run and then exit normally.)

I've done a simple change that seems to work, though throwing an error to trigger the catch in cmd.js, might be better style? Please let me know what you think, thanks!